### PR TITLE
Add simple CLIP demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # gen_moc
+
+This repository contains a minimal demo application that computes image–text similarity using OpenAI's CLIP model. A simple UI built with [Gradio](https://gradio.app/) allows you to upload an image and enter a text prompt to see how similar they are.
+
+## Requirements
+
+- Python 3.8+
+- `torch`
+- `transformers`
+- `gradio`
+- `Pillow`
+
+You can install the dependencies with:
+
+```bash
+pip install torch torchvision transformers gradio pillow
+```
+
+The CPU versions of the packages are sufficient to run the demo.
+
+## Running the app
+
+Launch the application with:
+
+```bash
+python app.py
+```
+
+A local web server will start and display an interface where you can upload an image, enter text, and view the similarity score produced by CLIP.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,32 @@
+import gradio as gr
+from PIL import Image
+import torch
+from transformers import CLIPProcessor, CLIPModel
+
+# Load the CLIP model and processor
+model_name = "openai/clip-vit-base-patch32"
+model = CLIPModel.from_pretrained(model_name)
+processor = CLIPProcessor.from_pretrained(model_name)
+
+def compute_similarity(image: Image.Image, text: str) -> float:
+    """Compute cosine similarity between an image and text using CLIP."""
+    if image is None or text is None or text.strip() == "":
+        return 0.0
+    inputs = processor(text=[text], images=image, return_tensors="pt")
+    with torch.no_grad():
+        outputs = model(**inputs)
+    # CLIP outputs the similarity logits scaled by a temperature parameter
+    similarity = outputs.logits_per_image.squeeze().item()
+    return float(similarity)
+
+iface = gr.Interface(
+    fn=compute_similarity,
+    inputs=[gr.Image(type="pil"), gr.Textbox(label="Input Text")],
+    outputs=gr.Number(label="Similarity"),
+    title="Image-Text Similarity Demo",
+    description="Upload an image and enter text to compute similarity using CLIP",
+)
+
+if __name__ == "__main__":
+    iface.launch()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+torch
+transformers
+gradio
+pillow


### PR DESCRIPTION
## Summary
- add `app.py` implementing a CLIP-based similarity demo with Gradio
- document setup and usage in `README.md`
- include `requirements.txt` for dependencies

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684a86dfdd6c8326b391bd5c65a20f1b